### PR TITLE
Update dependency range for oxid-esales/oxideshop-ce to support >=7.0…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     },
     "require":     {
         "php": ">=8.0",
-        "oxid-esales/oxideshop-ce": ">=7.0.0 <7.2.0"
+        "oxid-esales/oxideshop-ce": ">=7.0.0 <7.4.0"
     },
     "conflict": {
         "oxid-esales/oxideshop-ce": "<7.0"


### PR DESCRIPTION
….0 and <7.4.0.