### PR TITLE
Update dependency range for oxid-esales/oxideshop-ce to support >=7.0…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name":        "digidesk/dd_trustedshops_features",
     "description": "This is the Trusted Shops module for the OXID 7 eShop.",
-    "version":     "3.0.2",
+    "version":     "3.0.3",
     "type":        "oxideshop-module",
     "keywords":    [
         "oxid",


### PR DESCRIPTION
….0 and <7.4.0.